### PR TITLE
docs: add Agent OS documentation tab with full docs structure

### DIFF
--- a/06-agent-os/capabilities.mdx
+++ b/06-agent-os/capabilities.mdx
@@ -1,0 +1,72 @@
+---
+title: Capabilities
+description: A unified overview of all AgentOS capabilities across control modes and runtime modes.
+---
+
+AgentOS provides a set of capabilities for controlling machines. What's available depends on the [control mode](/06-agent-os/control-modes) and [runtime mode](/06-agent-os/runtime-modes) you use.
+
+## Desktop Control
+
+| Capability | Host Mode | Companion Mode | Description |
+| --- | --- | --- | --- |
+| Screenshots | Available | Available (via HDMI capture) | Capture the current screen state. |
+| GPU-accelerated screenshots | Available | — | Take screenshots on GPU for better performance. |
+| Keyboard input | Available | Available (via USB / Bluetooth HID) | Simulate key presses and combinations. |
+| Real Unicode typing | Available | — | Native Unicode input (not clipboard-based). |
+| Mouse input | Available | Available (via USB / Bluetooth HID) | Click, move, drag, and scroll. |
+| Multi-display support | Available | — | Interact with multiple monitors. |
+| Window management | Available | — | Select, resize, move, and focus windows. |
+| Process management | Available | — | Start, stop, and monitor OS processes. |
+| Automation recovery | Available | — | Recover automatically from display changes. |
+| CLI | Available | — | Enhanced command-line interface. |
+
+## Windows Service (OS Service Mode Only)
+
+These capabilities require AgentOS to be installed as a [Windows service](/06-agent-os/installation).
+
+| Capability | Status | Description |
+| --- | --- | --- |
+| SYSTEM-level service | Available | Run as a Windows service with SYSTEM privileges. |
+| RDP disconnect recovery | Available | Keep automation running when RDP sessions disconnect. |
+| Login screen automation | Available | Interact with the Windows logon screen. |
+| Secure Attention Sequence | Available | Send CTRL+ALT+DEL programmatically. |
+| Background session automation | Available | Automate sessions that are not in the foreground. |
+| Multi-user session control | Planned | Control multiple user sessions on the same machine. |
+| Virtual display | Planned | Create virtual displays for headless environments. |
+
+## Mobile Devices
+
+| Capability | Status | Description |
+| --- | --- | --- |
+| ADB (Android) | Available | Control Android devices via USB. |
+| IDB (iOS) | Planned | Control iOS devices via USB. |
+
+## Hardware (Companion Mode Only)
+
+| Capability | Status | Description |
+| --- | --- | --- |
+| HID over USB | Available | Simulate keyboard and mouse via USB connection. |
+| HID over Bluetooth | Available | Simulate keyboard and mouse via Bluetooth. |
+| Screenshot via media stream | Available | Capture screen output via HDMI-to-USB dongle or webcam. |
+| Raspberry Pi support | Planned | Use a Raspberry Pi as the companion device. |
+
+## Platform Support
+
+| Platform | Host Mode | Companion Mode |
+| --- | --- | --- |
+| Windows 10 22H2+ | Available | — |
+| Windows 11 | Available | — |
+| Windows Server 2022+ | Available | — |
+| Windows 10 < 22H2 | Available | — |
+| Windows Server 2019 | Available | — |
+| macOS | Available | — |
+| Linux | Available | — |
+| Android | — | Available (ADB) |
+| iOS | — | Planned (IDB) |
+
+## Future
+
+| Capability | Status | Description |
+| --- | --- | --- |
+| C# API | Planned | Native C# interface for .NET integrations. |
+| Future automation APIs | Planned | Integration with emerging OS automation frameworks. |

--- a/06-agent-os/concepts.mdx
+++ b/06-agent-os/concepts.mdx
@@ -1,0 +1,79 @@
+---
+title: Concepts
+description: The key concepts behind AgentOS — how control modes, runtime modes, and capabilities fit together.
+---
+
+AgentOS has three core concepts that determine what it can do and how it connects to a target machine. While the concepts below involve OS-level services, kernel drivers, and hardware interfaces, **you don't need to understand these internals to use AgentOS**. The installer handles the complexity — non-technical users can set up AgentOS through a guided UI without touching configuration files or the command line.
+
+AgentOS is **platform independent** — it supports Windows, macOS, Linux, Android, and iOS (planned), so the same agent code works across operating systems.
+
+```mermaid
+graph TD
+    A[Agent Code<br/>Python SDK] -->|gRPC| B[AgentOS]
+    B --> C{Control Mode}
+    C -->|Host Mode| D[OS-level APIs<br/>on target machine]
+    C -->|Companion Mode| E[Hardware interfaces<br/>from external device]
+    B --> F{Runtime Mode}
+    F -->|Standalone| G[User-space process]
+    F -->|OS Service| H[Windows SYSTEM service]
+```
+
+## Control Modes
+
+Control modes define **how AgentOS connects to the target machine**. There are two:
+
+- **Host Mode** — AgentOS runs directly on the target as software. It uses OS-level APIs for screenshots, input, and window management. This is the most common setup.
+- **Companion Mode** — AgentOS runs on a separate device and controls the target through hardware (USB, Bluetooth, HDMI capture) or device bridges (ADB, IDB). No software installation on the target is needed.
+
+Both modes expose the same interface to your agent code — the SDK doesn't need to know which mode is active.
+
+[Learn more about Control Modes →](/06-agent-os/control-modes)
+
+## Runtime Modes
+
+Runtime modes define **how AgentOS runs on the machine it's installed on**. There are two:
+
+- **Standalone** — AgentOS runs as a regular process in the user's session. Install via `pip install askui-agent-os`. Best for local development and testing.
+- **OS Service** — AgentOS runs as a Windows system service with SYSTEM privileges. Install via the [Service Installer](/06-agent-os/installation). Best for CI/CD, headless VMs, and enterprise deployments.
+
+The runtime mode only applies to Host Mode. Companion Mode always runs standalone on the companion device.
+
+[Learn more about Runtime Modes →](/06-agent-os/runtime-modes)
+
+## Capabilities
+
+Capabilities are the building blocks your agents use — screenshots, keyboard input, mouse control, window management, process management, and more.
+
+What's available depends on the combination of control mode and runtime mode:
+
+| | Host Mode (Standalone) | Host Mode (OS Service) | Companion Mode |
+| --- | --- | --- | --- |
+| Screenshots | Yes | Yes | Yes (HDMI capture) |
+| Keyboard & mouse | Yes | Yes | Yes (USB/Bluetooth HID) |
+| Window & process management | Yes | Yes | — |
+| RDP resilience | — | Yes | — |
+| Logon screen & CTRL+ALT+DEL | — | Yes | — |
+| Mobile devices (ADB/IDB) | — | — | Yes |
+
+[See all Capabilities →](/06-agent-os/capabilities)
+
+## How They Fit Together
+
+Think of it as two independent choices:
+
+1. **Control mode** — *How do I reach the target?* Software on the target (Host) or hardware from outside (Companion).
+2. **Runtime mode** — *How does AgentOS run?* As a regular process (Standalone) or as a system service (OS Service).
+
+Your agent code stays the same regardless of the combination. The SDK connects to AgentOS via gRPC, and AgentOS handles the rest.
+
+<CardGroup cols={3}>
+  <Card title="Control Modes" icon="desktop" href="/06-agent-os/control-modes">
+    Host Mode vs Companion Mode.
+  </Card>
+  <Card title="Runtime Modes" icon="toggle-on" href="/06-agent-os/runtime-modes">
+    Standalone vs OS Service.
+  </Card>
+  <Card title="Capabilities" icon="list-check" href="/06-agent-os/capabilities">
+    Full capability matrix.
+  </Card>
+</CardGroup>

--- a/06-agent-os/configuration.mdx
+++ b/06-agent-os/configuration.mdx
@@ -1,0 +1,38 @@
+---
+title: Silent Installer
+description: Silent installation parameters and runtime configuration for the AgentOS Windows service.
+---
+
+## Installer Parameters
+
+Override defaults during silent installation by passing these parameters:
+
+| Parameter | Default | Description |
+| --- | --- | --- |
+| `APPDIR` | `C:\Program Files\askui GmbH\AskUI AgentOS` | Install location. Must be accessible to all users. |
+| `SERVICE_SUBNET` | `127.0.0.1` | Network subnet the service listens on. |
+| `SERVICE_LISTENING_PORT` | `26000` | Main service port. |
+| `SERVICE_LOG_LEVEL` | `Debug` | Log verbosity: `Info` or `Debug`. |
+| `SERVICE_ENABLE_SAS` | `1` | Enable Secure Attention Sequence (CTRL+ALT+DEL). Set to `0` to disable. |
+| `SERVICE_EXECUTION_ENGINE_ELEVATED` | `0` | Run execution engine with elevated privileges. Set to `1` to enable. |
+| `SERVICE_EXECUTION_ENGINE_LISTENING_PORT` | `23000` | Execution engine port. |
+| `SERVICE_EXECUTION_ENGINE_VISIBLE` | `0` | Show execution engine UI/process. Set to `1` to make visible. |
+| `SERVICE_TRANSFER_SESSION_ON_DISCONNECT` | `1` | Transfer remote sessions on disconnect (RDP resilience). Set to `0` to disable. |
+
+**Example:**
+
+```bash
+"<installer_path>" /qn SERVICE_LISTENING_PORT=27000 SERVICE_LOG_LEVEL=Info /l*vx installer.log
+```
+
+<Tip>Append `/l*vx installer.log` to any silent install command to write detailed logs.</Tip>
+
+## Runtime Configuration
+
+After installation, the service can be further tuned by editing:
+
+```
+C:\Program Files\askui GmbH\AskUI AgentOS\Configs\AskuiCoreService.json
+```
+
+<Warning>After changing this file, **restart the computer** for changes to take effect.</Warning>

--- a/06-agent-os/control-modes.mdx
+++ b/06-agent-os/control-modes.mdx
@@ -1,0 +1,56 @@
+---
+title: Control Modes
+description: How AgentOS connects to and controls target machines — Host Mode vs Companion Mode.
+---
+
+AgentOS operates in two control modes that determine *how* it connects to and controls a target machine. Both modes expose the same core concepts (screenshots, input, automation) — but the connection method differs.
+
+## Host Mode
+
+AgentOS runs directly **on the target machine** as software. It controls the desktop via OS-level APIs.
+
+- Agent code and AgentOS run on the same machine (or connect over the network).
+- Full access to OS-level features: window management, process control, multi-display support.
+- Can run as a [Windows service](/06-agent-os/installation) for SYSTEM privileges, RDP resilience, and logon screen control.
+- Supports Windows, macOS, and Linux.
+
+**Best for:** Desktop automation, CI/CD pipelines, enterprise VMs.
+
+## Companion Mode
+
+AgentOS runs on an **external device** and controls the target through hardware interfaces. No software needs to be installed on the target.
+
+- Input is sent via USB or Bluetooth HID (keyboard and mouse emulation).
+- Screen capture happens via HDMI-to-USB capture devices.
+- Mobile devices are controlled via ADB (Android) or IDB (iOS, planned).
+
+**Best for:** Locked-down environments, embedded systems, kiosks, mobile devices, and any target where you cannot install software.
+
+## Comparison
+
+| | Host Mode | Companion Mode |
+| --- | --- | --- |
+| **Where AgentOS runs** | On the target machine | On an external device |
+| **Connection to target** | OS-level APIs | Hardware (USB, Bluetooth, HDMI) or device bridge (ADB/IDB) |
+| **Software on target** | Required | Not required |
+| **OS service support** | Yes (Windows) | No |
+| **Platform support** | Windows, macOS, Linux | Any device with USB/HDMI/Bluetooth; Android (ADB), iOS (IDB planned) |
+
+For a detailed breakdown of what each mode can do, see [Capabilities](/06-agent-os/capabilities).
+
+## What's Next?
+
+<CardGroup cols={2}>
+  <Card title="Capabilities" icon="list-check" href="/06-agent-os/capabilities">
+    Full list of capabilities by control mode.
+  </Card>
+  <Card title="Deployment Scenarios" icon="sitemap" href="/06-agent-os/deployment-scenarios">
+    Find the right setup for your target.
+  </Card>
+  <Card title="Runtime Modes" icon="toggle-on" href="/06-agent-os/runtime-modes">
+    Standalone vs OS service — choose the right runtime.
+  </Card>
+  <Card title="Install as Service" icon="server" href="/06-agent-os/installation">
+    Set up AgentOS as a Windows service for CI/CD and enterprise.
+  </Card>
+</CardGroup>

--- a/06-agent-os/deployment-ci.mdx
+++ b/06-agent-os/deployment-ci.mdx
@@ -1,0 +1,92 @@
+---
+title: CI/CD Integration
+description: Run AgentOS unattended in pipelines, on VMs, or with connected devices.
+---
+
+You're running agents unattended in a pipeline or on remote infrastructure. The install method depends on whether you need OS service capabilities (RDP resilience, SYSTEM privileges) or standalone mode is sufficient.
+
+## Windows VM
+
+Run automation directly on a Windows VM that is part of your CI/CD pipeline. AgentOS runs as an OS service with SYSTEM privileges.
+
+**When to use:** Your CI runner *is* the Windows machine you want to automate.
+
+**Install:** [Service Installer](/06-agent-os/installation) on the VM.
+
+```mermaid
+graph LR
+    A[Python SDK] -->|gRPC| B[AgentOS<br/>OS Service] -->  C[Desktop<br/>SYSTEM privileges]
+    subgraph Windows VM
+        direction LR
+        A
+        B
+        C
+    end
+```
+
+The Python SDK and AgentOS both run on the same VM. The OS service ensures automation continues even if no user is logged in or the RDP session disconnects.
+
+## Remote Windows VM
+
+Automate a Windows VM from a separate CI runner. The SDK runs on the CI runner and connects to AgentOS on the remote VM over the network.
+
+**When to use:** Your CI runner is Linux/macOS but you need to automate a Windows desktop. Or your pipeline orchestrates work across multiple machines.
+
+**Install:** [Service Installer](/06-agent-os/installation) on the remote VM.
+
+```mermaid
+graph LR
+    A[Python SDK] -->|gRPC<br/>over network| B[AgentOS<br/>OS Service]
+    B --> C[Desktop]
+    subgraph CI Runner
+        A
+    end
+    subgraph Remote Windows VM
+        B
+        C
+    end
+```
+
+The SDK connects to AgentOS over the network via gRPC. The OS service on the remote VM handles desktop control independently — RDP disconnects, logon screens, and headless operation are all supported.
+
+## macOS / Linux CI Runner
+
+Run automation on a macOS or Linux CI runner. AgentOS runs in standalone mode.
+
+**When to use:** Your CI pipeline runs on macOS or Linux and you want to automate the desktop on that same runner.
+
+**Install:** `pip install askui-agent-os`
+
+```mermaid
+graph LR
+    A[Python SDK] -->|gRPC| B[AgentOS<br/>Standalone] --> C[Desktop<br/>macOS / Linux]
+    subgraph CI Runner
+        direction LR
+        A
+        B
+        C
+    end
+```
+
+Same as local development — AgentOS runs in standalone mode alongside your test code. Ensure the CI runner has a display (real or virtual) available.
+
+## Mobile Device in CI
+
+Automate Android or iOS devices connected to your CI runner via USB.
+
+**When to use:** Mobile testing in your pipeline — the device is physically connected to the CI runner.
+
+**Install:** `pip install askui-agent-os` on the CI runner.
+
+```mermaid
+graph LR
+    A[Python SDK] -->|gRPC| B[AgentOS<br/>Standalone]
+    B -->|USB / ADB| D[Android Device]
+    B -->|USB / IDB| E[iOS Device]
+    subgraph CI Runner
+        A
+        B
+    end
+```
+
+AgentOS runs on the CI runner and communicates with the connected device over USB. The CI runner needs physical USB access to the device (or a USB-over-network solution).

--- a/06-agent-os/deployment-local.mdx
+++ b/06-agent-os/deployment-local.mdx
@@ -1,0 +1,71 @@
+---
+title: Local Development
+description: Deploy AgentOS on your own machine for desktop, mobile, or hardware-based automation.
+---
+
+You're building and testing agents on your own machine. In all local scenarios, you install AgentOS via `pip install askui-agent-os` and your Python SDK connects to the local AgentOS instance over gRPC.
+
+## Desktop
+
+Automate the desktop on your own Windows, macOS, or Linux machine. AgentOS runs in standalone mode alongside your agent code.
+
+**When to use:** Day-to-day development, debugging, and interactive testing.
+
+**Install:** `pip install askui-agent-os` → [Standalone Installer](/06-agent-os/quickstart)
+
+```mermaid
+graph LR
+    A[Python SDK] -->|gRPC| B[AgentOS<br/>Standalone] --> C[Desktop<br/>Windows / macOS / Linux]
+    subgraph Your Machine
+        direction LR
+        A
+        B
+        C
+    end
+```
+
+Your agent code and AgentOS run in the same machine. The SDK sends commands via gRPC, and AgentOS translates them into OS-level actions — screenshots, keyboard input, mouse control.
+
+## Mobile Device
+
+Automate an Android or iOS device connected to your machine via USB.
+
+**When to use:** Mobile app testing, device interaction during development.
+
+**Install:** `pip install askui-agent-os` → [Standalone Installer](/06-agent-os/quickstart)
+
+```mermaid
+graph LR
+    A[Python SDK] -->|gRPC| B[AgentOS<br/>Standalone]
+    B -->|USB / ADB| D[Android Device]
+    B -->|USB / IDB| E[iOS Device]
+    subgraph Your Machine
+        A
+        B
+    end
+```
+
+AgentOS acts as a bridge: it receives commands from the SDK via gRPC and forwards them to the connected device using ADB (Android) or IDB (iOS). The device stays connected via USB.
+
+<Note>You only need one of ADB or IDB depending on your target device — both are shown for completeness.</Note>
+
+## KVM (External Hardware)
+
+Control a target device through physical hardware connections — keyboard/mouse via USB or Bluetooth, screen capture via HDMI.
+
+**When to use:** The target device can't have software installed on it (locked-down environments, embedded systems, kiosks).
+
+**Install:** `pip install askui-agent-os` → [Standalone Installer](/06-agent-os/quickstart)
+
+```mermaid
+graph LR
+    A[Python SDK] -->|gRPC| B[AgentOS<br/>Standalone]
+    B -->|USB / Bluetooth<br/>Keyboard + Mouse| D[Target Device]
+    D -->|HDMI Capture<br/>Screenshots| B
+    subgraph Your Machine
+        A
+        B
+    end
+```
+
+This is [Companion Mode](/06-agent-os/control-modes#companion-mode): AgentOS simulates keyboard and mouse input over USB or Bluetooth HID, and captures the target's screen via an HDMI-to-USB capture device. No software installation on the target is required.

--- a/06-agent-os/deployment-multi-device.mdx
+++ b/06-agent-os/deployment-multi-device.mdx
@@ -1,0 +1,98 @@
+---
+title: Multi-Device Setups
+description: Control multiple targets from a single agent or pipeline.
+---
+
+You need to automate across multiple targets — desktops, VMs, mobile devices, or hardware. In multi-device setups, the Python SDK connects to **each AgentOS instance separately** via gRPC. There is no AgentOS-to-AgentOS communication.
+
+## Windows + Mobile Device
+
+Automate a Windows desktop and a mobile device from the same pipeline.
+
+**When to use:** Cross-platform testing — e.g., a web app on Windows and its companion mobile app.
+
+```mermaid
+graph LR
+    subgraph CI Runner
+        A[Python SDK]
+    end
+    A -->|gRPC| B
+    A -->|gRPC| C
+    subgraph Windows VM
+        B[AgentOS<br/>OS Service] --> D[Desktop]
+    end
+    C[AgentOS<br/>Standalone] -->|ADB / IDB| E[Android / iOS]
+```
+
+The SDK manages two independent gRPC connections: one to the AgentOS OS Service on the Windows VM, and one to a local AgentOS instance that controls the mobile device.
+
+## Multiple Windows VMs
+
+Scale desktop automation across several Windows VMs in parallel.
+
+**When to use:** Running the same tests across different Windows configurations, or distributing a large test suite across machines for faster execution.
+
+```mermaid
+graph LR
+    subgraph CI Runner
+        A[Python SDK]
+    end
+    A -->|gRPC| B1
+    A -->|gRPC| B2
+    A -->|gRPC| B3
+    subgraph VM 1
+        B1[AgentOS<br/>OS Service] --> C1[Desktop]
+    end
+    subgraph VM 2
+        B2[AgentOS<br/>OS Service] --> C2[Desktop]
+    end
+    subgraph VM 3
+        B3[AgentOS<br/>OS Service] --> C3[Desktop]
+    end
+```
+
+Each VM runs its own AgentOS OS Service. The SDK connects to all of them independently. Your pipeline code decides which commands go to which VM.
+
+## Multiple Mobile Devices
+
+Automate several Android (or iOS) devices connected to the same machine.
+
+**When to use:** Testing across different device models, screen sizes, or OS versions in parallel.
+
+```mermaid
+graph LR
+    subgraph CI Runner
+        A[Python SDK]
+    end
+    A -->|gRPC| B1
+    A -->|gRPC| B2
+    A -->|gRPC| B3
+    B1[AgentOS 1] -->|ADB| D1[Android Device 1]
+    B2[AgentOS 2] -->|ADB| D2[Android Device 2]
+    B3[AgentOS 3] -->|ADB| D3[Android Device 3]
+```
+
+Each device gets its own AgentOS instance. The SDK connects to each one over gRPC and routes commands to the right device.
+
+## Desktop + KVM Device
+
+Combine software-based desktop control with hardware-based control of an external device.
+
+**When to use:** Testing interactions between a desktop application and a physical device that can't have software installed (e.g., an embedded system, kiosk, or industrial controller).
+
+```mermaid
+graph LR
+    A[Python SDK] -->|gRPC| B[AgentOS<br/>Host Mode]
+    A -->|gRPC| C[AgentOS<br/>Companion Mode]
+    B --> D[Local Desktop]
+    C -->|USB / Bluetooth<br/>Keyboard + Mouse| E[Target Device]
+    E -->|HDMI Capture<br/>Screenshots| C
+    subgraph Your Machine
+        A
+        B
+        C
+        D
+    end
+```
+
+Two AgentOS instances run on the same machine, each in a different [control mode](/06-agent-os/control-modes): one controls the local desktop (Host Mode), the other controls the external device through hardware (Companion Mode). The SDK connects to both independently.

--- a/06-agent-os/deployment-scenarios.mdx
+++ b/06-agent-os/deployment-scenarios.mdx
@@ -1,0 +1,34 @@
+---
+title: Deployment Scenarios
+description: Find the right AgentOS setup for your target — local dev, CI/CD, or multi-device.
+---
+
+Choose the deployment scenario that matches your environment. Each scenario explains the architecture, how the Python SDK connects to AgentOS, and which installer to use.
+
+<CardGroup cols={3}>
+  <Card title="Local Development" icon="laptop" href="/06-agent-os/deployment-local">
+    Build and test agents on your own machine — desktop, mobile, or external hardware.
+  </Card>
+  <Card title="CI/CD Integration" icon="gears" href="/06-agent-os/deployment-ci">
+    Run agents unattended in pipelines, on VMs, or with connected devices.
+  </Card>
+  <Card title="Multi-Device Setups" icon="diagram-project" href="/06-agent-os/deployment-multi-device">
+    Control multiple targets from a single agent or pipeline.
+  </Card>
+</CardGroup>
+
+## Quick Reference
+
+Not sure which scenario fits? Find your target below.
+
+| Your target | Scenario | Install method |
+| --- | --- | --- |
+| Windows / macOS / Linux desktop | [Local Development](/06-agent-os/deployment-local#desktop) | `pip install askui-agent-os` |
+| Android device (USB) | [Local Development](/06-agent-os/deployment-local#mobile-device) | `pip install askui-agent-os` |
+| iOS device (USB) | [Local Development](/06-agent-os/deployment-local#mobile-device) | `pip install askui-agent-os` (Planned) |
+| Locked-down device (no software install) | [Local Development](/06-agent-os/deployment-local#kvm-external-hardware) | `pip install askui-agent-os` |
+| Windows VM in CI/CD | [CI/CD Integration](/06-agent-os/deployment-ci#windows-vm) | [Service Installer](/06-agent-os/installation) |
+| Remote Windows VM from CI runner | [CI/CD Integration](/06-agent-os/deployment-ci#remote-windows-vm) | [Service Installer](/06-agent-os/installation) |
+| macOS / Linux CI runner | [CI/CD Integration](/06-agent-os/deployment-ci#macos--linux-ci-runner) | `pip install askui-agent-os` |
+| Mobile device in CI | [CI/CD Integration](/06-agent-os/deployment-ci#mobile-device-in-ci) | `pip install askui-agent-os` |
+| Multiple targets at once | [Multi-Device Setups](/06-agent-os/deployment-multi-device) | Depends on targets |

--- a/06-agent-os/enterprise.mdx
+++ b/06-agent-os/enterprise.mdx
@@ -1,0 +1,58 @@
+---
+title: Enterprise Features
+description: Security, compliance, and enterprise-grade capabilities for AgentOS.
+---
+
+AgentOS is designed for enterprise environments that require security controls, audit capabilities, and compliance features.
+
+## Security & Compliance
+
+| Feature | Status | Description |
+| --- | --- | --- |
+| Signed binaries | Available | Code-signed installers and binaries — no SmartScreen or Execution Policy bypasses needed. |
+| Application whitelisting | Planned | Restrict which applications AgentOS can interact with. |
+| Filesystem whitelisting | Planned | Restrict filesystem paths AgentOS can access. |
+| Audit logs | Planned | Detailed logs of all actions taken by AgentOS for compliance and forensics. |
+| Application logs | Planned | Structured application-level logging for monitoring. |
+| Network scanning | Planned | Visibility into network activity originating from AgentOS. |
+
+## Support
+
+| Feature | Status | Description |
+| --- | --- | --- |
+| Dedicated support | Planned | Priority support channel for enterprise customers. |
+| Vulnerability SLA | Planned | Guaranteed response times for security vulnerabilities. |
+
+## Connectivity
+
+| Feature | Status | Description |
+| --- | --- | --- |
+| P2P connection | Planned | Direct peer-to-peer connections between AgentOS instances. |
+| Video stream | Planned | Real-time video streaming of the controlled desktop. |
+| File stream | Planned | File transfer including log file streaming. |
+
+## Industry Protocols
+
+Integration with industrial communication standards for factory automation, IoT, and embedded testing.
+
+| Protocol | Status | Description |
+| --- | --- | --- |
+| CAN bus | Planned | Automotive and industrial controller area network. |
+| OPC | Planned | Classic OPC for industrial data exchange. |
+| OPC UA | Planned | Modern OPC Unified Architecture. |
+| MQTT | Planned | Lightweight messaging for IoT devices. |
+| Zigbee | Planned | Low-power wireless for smart devices. |
+| Serial (RS-232 / RS-485) | Planned | Serial communication for legacy and embedded devices. |
+
+## Test Bench (Extended Testing Devices)
+
+Physical hardware integration for automated test setups.
+
+| Device | Status | Description |
+| --- | --- | --- |
+| Relay control (Ethernet) | Planned | Switch power or signals via Ethernet relays. |
+| Relay control (USB) | Planned | Switch power or signals via USB relays. |
+| SwitchBot / Fingerbot | Planned | Physical button pressing via robotic actuators. |
+| Bluetooth dongle | Planned | Bluetooth connectivity for test devices. |
+| Wi-Fi dongle | Planned | Wi-Fi connectivity for test devices. |
+| Workbench integration | Planned | Full test bench orchestration. |

--- a/06-agent-os/index.mdx
+++ b/06-agent-os/index.mdx
@@ -1,0 +1,72 @@
+---
+title: Overview
+description: What is AgentOS, why it exists, and the key concepts you need to know.
+---
+
+AgentOS is the runtime layer that gives AI agents direct control over a machine's operating system — keyboard, mouse, screen, and system-level functions. It sits between your agent code and the OS, handling the low-level interactions so your agents can focus on tasks.
+
+**Designed for everyone, not just developers.** AgentOS is built so that non-technical users can install it and get it running without writing code or configuring system internals. The UI installer guides you through setup, the SDK auto-detects the service, and sensible defaults mean you don't need to touch configuration files to get started.
+
+**Platform independent.** AgentOS runs on Windows, macOS, and Linux. In [Companion Mode](/06-agent-os/control-modes#companion-mode), it can also control Android devices, iOS devices (planned), and any machine reachable through hardware interfaces — regardless of what OS the target runs.
+
+## How It Works
+
+AgentOS operates in two **control modes**:
+
+- **[Host Mode](/06-agent-os/control-modes#host-mode)** — AgentOS runs directly on the target machine as software. It controls the desktop via OS-level APIs with full access to screenshots, input, windows, and processes.
+- **[Companion Mode](/06-agent-os/control-modes#companion-mode)** — AgentOS runs on an external device (e.g. Raspberry Pi) and controls the target machine through hardware interfaces (USB, Bluetooth, HDMI capture). No software installation on the target required.
+
+Both modes expose the same **capabilities** to your agents — the building blocks for screen reading, input simulation, window management, and more.
+
+## Why AgentOS?
+
+### vs. Open Source (PyAutoGUI, xdotool, etc.)
+
+Open-source desktop automation libraries run **in the user's session only**. That works for simple scripting but breaks down for real-world agent deployments:
+
+- **No service mode** — when the user logs off or the RDP session disconnects, automation stops.
+- **No logon screen control** — you can't automate Windows logon, lock screens, or UAC prompts.
+- **No CTRL+ALT+DEL** — Secure Attention Sequence requires a kernel-level driver. User-space tools cannot send it.
+- **No session resilience** — if an RDP session drops, the desktop locks and screenshots go black.
+- **User-level privileges only** — no access to SYSTEM-level operations.
+
+### vs. Building It Yourself
+
+You *can* build OS-level control from scratch. Here's what that involves:
+
+- **Windows service with session management** — running as SYSTEM, attaching to interactive sessions, handling session 0 isolation.
+- **Secure Attention Sequence driver** — a signed kernel driver to send CTRL+ALT+DEL.
+- **RDP session transfer** — detecting disconnects and keeping the desktop alive for screenshot capture.
+- **Logon screen interaction** — injecting input on the secure desktop.
+- **Cross-version compatibility** — handling differences across Windows 10, 11, Server 2019, 2022.
+
+This is months of kernel and systems-level engineering before you write a single line of agent logic.
+
+### Comparison
+
+| Capability | AgentOS | Open Source | DIY |
+| --- | --- | --- | --- |
+| OS service mode | Yes | No | Months of work |
+| RDP resilience | Yes | No | Kernel-level effort |
+| Logon screen control | Yes | No | Requires SAS driver |
+| Send CTRL+ALT+DEL | Yes | No | Requires signed kernel driver |
+| CI/CD headless | Yes | No | Custom service wrapper |
+| SYSTEM privileges | Yes | No | Manual service setup |
+| External device control | Yes | No | Custom hardware integration |
+| Industry protocols | Planned | No | Custom integration per protocol |
+| Maintained and versioned | Yes | Varies | On you |
+| Time to first automation | Minutes | Hours | Months |
+
+## What's Next?
+
+<CardGroup cols={2}>
+  <Card title="Quickstart" icon="rocket" href="/06-agent-os/quickstart">
+    Get AgentOS running in under 5 minutes.
+  </Card>
+  <Card title="Control Modes" icon="desktop" href="/06-agent-os/control-modes">
+    Host Mode vs Companion Mode — how AgentOS connects to targets.
+  </Card>
+  <Card title="Deployment Scenarios" icon="sitemap" href="/06-agent-os/deployment-scenarios">
+    Find the right setup for your target.
+  </Card>
+</CardGroup>

--- a/06-agent-os/installation.mdx
+++ b/06-agent-os/installation.mdx
@@ -1,0 +1,59 @@
+---
+title: Service Installer
+description: Install AgentOS as a Windows system service for enterprise and CI/CD.
+---
+
+This page covers installing AgentOS as an **OS service** (Windows system service). For standalone mode, see the [Standalone Installer](/06-agent-os/quickstart).
+
+## Prerequisites
+
+- **Windows** (Windows 10, Windows 11, Windows Server 2019+)
+- **Administrator rights** — the installer will prompt for elevation if needed.
+
+## Enterprise Ready
+
+The installer ships with enterprise security requirements built in:
+
+- **Signed binaries** — no need to bypass SmartScreen, Gatekeeper, or Execution Policies.
+- **Separated binaries and data** — program files and configuration/data are stored separately, following security best practices.
+- **Enterprise proxy and CA support** — compatible with deep packet inspection setups.
+
+## UI Installation
+
+1. Run the AgentOS installer (EXE).
+2. If prompted, approve the administrator elevation request.
+3. Go through the installer and open the **config** page to set options.
+4. Click **Install** and wait for completion.
+5. Click **Finish**. If the installer asks to reboot, restart the machine so all changes take effect.
+
+## Silent Installation
+
+For scripts, CI, or unattended setups, run the installer from an **elevated** command prompt (Run as administrator).
+
+<Note>Replace `<version>` with the actual version number of your installer (e.g. `26.2.1.3`).</Note>
+
+**Basic silent install (defaults):**
+
+```bash
+"AskUI-Agent-OS-<version>-Service-Installer-Win-AMD64.exe" /qn
+```
+
+**Custom install with options:**
+
+```bash
+"<installer_path>" /qn APPDIR="C:\ASKUI" /l*vx installer.log
+```
+
+See [Configuration](/06-agent-os/configuration) for all available installer parameters.
+
+## After Installation
+
+- **Default install path:** `C:\Program Files\askui GmbH\AskUI AgentOS`
+- The AskUI Python SDK automatically detects the service and uses it instead of standalone mode.
+- After uninstalling the app, the SDK falls back to standalone mode.
+
+## Uninstalling
+
+<Warning>
+**Do not** remove or stop only the service from Windows Services. Always **uninstall the full AskUI AgentOS application** to clean up correctly.
+</Warning>

--- a/06-agent-os/quickstart.mdx
+++ b/06-agent-os/quickstart.mdx
@@ -1,0 +1,34 @@
+---
+title: Standalone Installer
+description: Install AgentOS in standalone mode via pip.
+---
+
+Install AgentOS locally in standalone mode. This is the fastest way to start building agents.
+
+## Prerequisites
+
+- Python 3.10 or higher
+
+## Install
+
+AgentOS is included as a dependency of the AskUI SDK. Most users already have it:
+
+```bash
+pip install askui-agent-os
+```
+
+<Note>If you installed the AskUI SDK, AgentOS is already available. You only need to install it separately if you want a specific version.</Note>
+
+## What's Next?
+
+<CardGroup cols={2}>
+  <Card title="Runtime Modes" icon="toggle-on" href="/06-agent-os/runtime-modes">
+    Understand standalone vs OS service mode.
+  </Card>
+  <Card title="Control Modes" icon="desktop" href="/06-agent-os/control-modes">
+    Host Mode vs Companion Mode — how AgentOS connects to targets.
+  </Card>
+  <Card title="Deploy as OS Service" icon="server" href="/06-agent-os/installation">
+    Set up AgentOS as a Windows service for CI/CD and enterprise.
+  </Card>
+</CardGroup>

--- a/06-agent-os/release-notes.mdx
+++ b/06-agent-os/release-notes.mdx
@@ -1,0 +1,20 @@
+---
+title: Release Notes
+description: AgentOS versioning scheme and release notes.
+---
+
+## Versioning
+
+AgentOS follows [CalVer](https://calver.org/) (Calendar Versioning) with the format **`YY.MM.PATCH`**:
+
+- **YY** — two-digit year (e.g. `26` for 2026)
+- **MM** — month (e.g. `2` for February)
+- **PATCH** — incremental patch number within that month
+
+Example: **26.2.2** = 2026, February, patch 2.
+
+**AgentOS uses the same version as the installer and the `askui-agent-os` pip package.** If you install the service with version **26.2.2**, the included AgentOS is also **26.2.2**.
+
+## Releases
+
+Release notes for each version will be published here.

--- a/06-agent-os/runtime-modes.mdx
+++ b/06-agent-os/runtime-modes.mdx
@@ -1,0 +1,42 @@
+---
+title: Runtime Modes
+description: Standalone vs OS Service — choose the right AgentOS runtime mode.
+---
+
+AgentOS can run in two modes. Choose based on your use case.
+
+## Standalone
+
+AgentOS runs as a regular process in the current user's session.
+
+**Best for:** Local development, interactive desktop use, and manual testing.
+
+```bash
+pip install askui-agent-os
+```
+
+That's it — your agent code uses AgentOS automatically.
+
+## OS Service
+
+AgentOS runs as a Windows system service with SYSTEM privileges.
+
+**Best for:** Enterprise deployments, CI/CD pipelines, headless VMs, and scenarios where RDP sessions may disconnect.
+
+The OS service requires the [Windows installer](/06-agent-os/installation). Once installed, the AskUI SDK automatically uses the service instead of standalone mode.
+
+## Feature Comparison
+
+| Feature | Standalone | OS Service |
+| --- | --- | --- |
+| **Primary use** | Local dev / desktop | Enterprise / CI/CD |
+| **CI/CD ready** | No | Yes (unattended/headless) |
+| **RDP resilience** | No (session locks on disconnect) | Yes (session transfer) |
+| **Logon screen control** | No | Yes |
+| **Send CTRL+ALT+DEL** | No | Yes (Secure Attention Sequence) |
+| **Privileges** | Current user | SYSTEM |
+| **Install method** | `pip install` | Windows installer |
+
+<Tip>
+**Not sure which to pick?** Start with **standalone** for development. Move to the **OS service** when you need CI/CD, headless VMs, or RDP resilience.
+</Tip>

--- a/06-agent-os/troubleshooting.mdx
+++ b/06-agent-os/troubleshooting.mdx
@@ -1,0 +1,41 @@
+---
+title: Troubleshooting
+description: Diagnose and fix common AgentOS issues.
+---
+
+<Note>The troubleshooting steps below apply to AgentOS running as a **Windows service**. For standalone mode on macOS or Linux, check the terminal output for errors.</Note>
+
+## Logs
+
+Service logs are stored at:
+
+```
+C:\Windows\System32\config\systemprofile\.askui\logs
+```
+
+Use these for troubleshooting startup, crash, or connectivity issues.
+
+## Common Issues
+
+### Service won't start
+
+1. Check the logs at the path above for error details.
+2. Verify the install completed successfully — look for errors in `installer.log` if you used `/l*vx installer.log` during installation.
+3. Ensure no other process is using the configured ports (default: `26000` for service, `23000` for execution engine).
+
+### SDK still uses standalone mode
+
+The SDK auto-detects the service. If it falls back to standalone:
+
+1. Verify the service is running in **Windows Services** (`services.msc`).
+2. Check that the service port (default `26000`) is reachable.
+
+### RDP session drops break automation
+
+Ensure `SERVICE_TRANSFER_SESSION_ON_DISCONNECT` is set to `1` (default). This keeps the desktop alive when an RDP session disconnects. See [Configuration](/06-agent-os/configuration).
+
+### Need to reinstall or remove
+
+<Warning>
+**Do not** stop or remove the service from Windows Services manually. Always **uninstall the full AskUI AgentOS application** via Windows Add/Remove Programs. This ensures proper cleanup so the SDK falls back to standalone mode.
+</Warning>

--- a/06-agent-os/vs-remote-control.mdx
+++ b/06-agent-os/vs-remote-control.mdx
@@ -1,0 +1,102 @@
+---
+title: AgentOS vs Remote Control Software
+description: How AgentOS differs from RDP, TeamViewer, UltraVNC, RustDesk, and other remote control tools.
+---
+
+Remote control software like RDP, TeamViewer, UltraVNC, and RustDesk lets **humans** view and interact with a remote desktop. AgentOS lets **AI agents** do the same — but the two are designed for fundamentally different purposes.
+
+## Different Goals
+
+| | Remote Control Software | AgentOS |
+| --- | --- | --- |
+| **Designed for** | Human operators viewing and controlling a remote screen | AI agents automating tasks programmatically |
+| **Input method** | Human moves mouse, types on keyboard | Agent sends commands via API (gRPC) |
+| **Screen access** | Streams video to a human viewer | Provides pixel-perfect screenshots to agent code |
+| **Session model** | Interactive session — a human must be watching | Unattended — no human needed |
+| **Automation support** | None (built for manual use) | Core purpose — screenshots, input, window/process management via API |
+
+## Why Not Just Use Remote Desktop?
+
+A common approach is to open an RDP or VNC session and run automation tools (like PyAutoGUI) inside it. This breaks down quickly:
+
+### Session Dependency
+
+Remote control software requires an **active session**. When the connection drops:
+
+- **RDP** locks the desktop — screenshots return a black screen, input stops working.
+- **VNC/TeamViewer/RustDesk** may keep the session alive, but there's no API to detect or recover from disconnects programmatically.
+
+AgentOS in [OS Service mode](/06-agent-os/runtime-modes#os-service) runs independently of any remote session. It transfers the session on disconnect and keeps automation running.
+
+### Unreliable Input
+
+Remote desktop protocols introduce a translation layer between the automation tool and the actual OS input system. This causes real-world issues that are difficult to debug:
+
+- **Clicks land in the wrong location** — RDP and VNC remap coordinates between the local and remote display. Differences in resolution, scaling (DPI), or multi-monitor setup cause mouse clicks to arrive at a different position than intended.
+- **Typing doesn't work or produces wrong characters** — remote protocols intercept and re-encode keyboard input. Special keys, keyboard layouts, Unicode characters, and fast key sequences can be lost, reordered, or misinterpreted. This is especially common with non-US keyboard layouts over RDP.
+- **Input timing is unpredictable** — network latency between the remote client and host means input events arrive with variable delay, causing race conditions in automation scripts that depend on timing.
+
+AgentOS injects input directly through OS-level APIs on the target machine — no protocol translation, no coordinate remapping, no network-induced timing issues.
+
+### No Programmatic Interface
+
+Remote control tools stream pixels to a human viewer. They don't provide:
+
+- A **screenshot API** that returns images your agent code can process.
+- A **structured input API** for keyboard and mouse commands.
+- **Window or process management** — you can't enumerate windows or start/stop processes through RDP.
+- **Event hooks** — no way to react programmatically to screen changes or session events.
+
+AgentOS exposes all of these through a gRPC API that the Python SDK connects to directly.
+
+### Security Constraints
+
+Remote desktop protocols operate within the user session and cannot reach privileged OS contexts:
+
+- **No logon screen access** — you can't automate the Windows lock screen or login prompt through RDP or VNC.
+- **No Secure Attention Sequence** — CTRL+ALT+DEL cannot be sent programmatically through remote control software. It requires a kernel-level driver.
+- **No SYSTEM privileges** — remote sessions run as the logged-in user, not as SYSTEM.
+
+AgentOS as an OS service runs with SYSTEM privileges and includes a signed kernel driver for Secure Attention Sequence. Beyond access, AgentOS is building a dedicated security layer with application and filesystem whitelisting, audit logs, and network scanning — giving enterprises fine-grained control over what agents can and cannot do. See [Enterprise Features](/06-agent-os/enterprise) for details.
+
+### Not Built for CI/CD
+
+Remote control software assumes a human will connect, do work, and disconnect. In CI/CD:
+
+- There's **no human to connect** — you need unattended, headless operation.
+- Sessions must survive **VM restarts, RDP disconnects, and pipeline retries** without manual intervention.
+- You need **deterministic startup** — the automation environment must be ready before your test code runs.
+
+AgentOS starts as a Windows service on boot, requires no active session, and is ready for automation immediately.
+
+## Comparison
+
+| Capability | AgentOS | RDP | TeamViewer | VNC (UltraVNC) | RustDesk |
+| --- | --- | --- | --- | --- | --- |
+| Programmatic screenshot API | Yes | No | No | No | No |
+| Programmatic input API | Yes (gRPC) | No | No | No | No |
+| Window/process management API | Yes | No | No | No | No |
+| Unattended (no human needed) | Yes | No (session locks) | Partial | Partial | Partial |
+| RDP disconnect resilience | Yes | N/A | No | No | No |
+| Logon screen automation | Yes | No | No | No | No |
+| Send CTRL+ALT+DEL | Yes | No | No | No | No |
+| SYSTEM privileges | Yes | No | No | No | No |
+| CI/CD ready | Yes | No | No | No | No |
+| No software on target | Yes (Companion Mode) | Requires RDP server | Requires agent | Requires VNC server | Requires agent |
+
+## Agent-Human-Interaction
+
+Remote control software is built for one model: a human controls a remote machine. AgentOS is building towards a collaborative model where **agents and humans work on the same machine together**.
+
+- **Shared desktop** — an agent can automate tasks in the background while a human uses the same machine. No need to lock out the user or take over the session.
+- **Handoff** — agents can prepare work (fill forms, navigate to the right screen, gather data) and hand control back to the human for decisions or approvals.
+- **Supervision** — a human can observe what the agent is doing in real time and intervene when needed, without disrupting the agent's session.
+
+This is a fundamentally different interaction model. Remote control tools assume one operator at a time — either a human is connected, or nobody is. AgentOS treats agents and humans as co-workers on the same machine.
+
+## When to Use What
+
+- **Remote control software** — when a human needs to view and interact with a remote machine manually.
+- **AgentOS** — when AI agents need to automate a machine programmatically, unattended, or alongside a human user.
+
+They can coexist: you can have RDP available for human debugging while AgentOS handles automated agent workflows on the same machine. AgentOS will keep running even when RDP sessions connect and disconnect.

--- a/mint.json
+++ b/mint.json
@@ -37,6 +37,10 @@
     {
       "name": "Reference",
       "url": "04-reference"
+    },
+    {
+      "name": "Agent OS",
+      "url": "06-agent-os"
     }
   ],
   "anchors": [
@@ -477,6 +481,55 @@
         "05-additional-resources/status-page",
         "05-additional-resources/trust-center",
         "05-additional-resources/agentic-instructions-example"
+      ]
+    },
+    {
+      "group": "Agent OS",
+      "pages": [
+        "06-agent-os/index",
+        {
+          "group": "Installation",
+          "icon": "rocket",
+          "pages": [
+            "06-agent-os/quickstart",
+            "06-agent-os/installation",
+            "06-agent-os/configuration"
+          ]
+        },
+        {
+          "group": "How-to Guides",
+          "icon": "wrench",
+          "pages": [
+            {
+              "group": "Deployment Scenarios",
+              "pages": [
+                "06-agent-os/deployment-scenarios",
+                "06-agent-os/deployment-local",
+                "06-agent-os/deployment-ci",
+                "06-agent-os/deployment-multi-device"
+              ]
+            },
+            "06-agent-os/troubleshooting"
+          ]
+        },
+        {
+          "group": "Understanding Agent OS",
+          "icon": "lightbulb",
+          "pages": [
+            "06-agent-os/concepts",
+            "06-agent-os/capabilities",
+            "06-agent-os/runtime-modes",
+            "06-agent-os/control-modes",
+            "06-agent-os/vs-remote-control"
+          ]
+        },
+        {
+          "group": "Reference",
+          "pages": [
+            "06-agent-os/enterprise"
+          ]
+        },
+        "06-agent-os/release-notes"
       ]
     }
   ],


### PR DESCRIPTION
Adds the Agent OS section as a new tab in the docs with pages covering overview, installation (standalone/service/silent), deployment scenarios (local/CI/multi-device), concepts, capabilities, control modes, runtime modes, enterprise features, troubleshooting, release notes, and a comparison with remote control software (RDP, TeamViewer, VNC, RustDesk).