### PR TITLE
docs: review fixes, comparison pages, and consistency improvements

### DIFF
--- a/06-agent-os/how-to-guides/deployment-scenarios.mdx
+++ b/06-agent-os/how-to-guides/deployment-scenarios.mdx
@@ -25,7 +25,7 @@ Not sure which scenario fits? Find your target below.
 | --- | --- | --- |
 | Windows / macOS / Linux desktop | [Local Development](/06-agent-os/how-to-guides/deployment-local#desktop) | `pip install askui-agent-os` |
 | Android device (USB) | [Local Development](/06-agent-os/how-to-guides/deployment-local#mobile-device) | `pip install askui-agent-os` |
-| iOS device (USB) | [Local Development](/06-agent-os/how-to-guides/deployment-local#mobile-device) | `pip install askui-agent-os` (Planned) |
+| iOS Simulator (macOS) | [Local Development](/06-agent-os/how-to-guides/deployment-local#mobile-device) | `pip install askui-agent-os` (Experimental) |
 | Locked-down device (no software install) | [Local Development](/06-agent-os/how-to-guides/deployment-local#kvm-external-hardware) | `pip install askui-agent-os` |
 | Windows VM in CI/CD | [CI/CD Integration](/06-agent-os/how-to-guides/deployment-ci#windows-vm) | [Service](/06-agent-os/installation/service) |
 | Remote Windows VM from CI runner | [CI/CD Integration](/06-agent-os/how-to-guides/deployment-ci#remote-windows-vm) | [Service](/06-agent-os/installation/service) |

--- a/06-agent-os/how-to-guides/troubleshooting.mdx
+++ b/06-agent-os/how-to-guides/troubleshooting.mdx
@@ -17,23 +17,6 @@ Use these for troubleshooting startup, crash, or connectivity issues.
 
 ## Common Issues
 
-### Service won't start
-
-1. Check the logs at the path above for error details.
-2. Verify the install completed successfully — look for errors in `installer.log` if you used `/l*vx installer.log` during installation.
-3. Ensure no other process is using the configured ports (default: `26000` for service, `23000` for execution engine).
-
-### SDK still uses standalone mode
-
-The SDK auto-detects the service. If it falls back to standalone:
-
-1. Verify the service is running in **Windows Services** (`services.msc`).
-2. Check that the service port (default `26000`) is reachable.
-
-### RDP session drops break automation
-
-Ensure `SERVICE_TRANSFER_SESSION_ON_DISCONNECT` is set to `1` (default). This keeps the desktop alive when an RDP session disconnects. See [Configuration](/06-agent-os/installation/silent).
-
 ### Agent can't press CTRL+ALT+DEL
 
 The login/lock screen cannot be automated unless the local security policy allows services to simulate a Secure Attention Sequence (SAS). To enable it:
@@ -46,6 +29,19 @@ Also verify that `SERVICE_ENABLE_SAS` is set to `1` (default) in the [Silent ins
 
 <Warning>
 The service includes a `windows.forceSas` option that overrides group policies. This is **not recommended** as it may trigger system integrity checks. Configure the GPE policy instead.
+</Warning>
+
+### Agent can't interact with apps running as Administrator
+
+Windows prevents non-elevated processes from sending input to elevated (Run as Administrator) applications. If your agent can't click or type into an app running as Administrator, you need to start the Remote Device Controller in elevated mode.
+
+To enable elevated mode:
+
+- **Service Installer (GUI)**: Open **Windows Add/Remove Programs**, find AskUI AgentOS, click **Modify**, and enable the elevated execution engine option. Alternatively, reinstall AgentOS with the option enabled.
+- **Silent Installer**: Set `SERVICE_EXECUTION_ENGINE_ELEVATED` to `1` — see [Silent installer parameters](/06-agent-os/installation/silent#parameters).
+
+<Warning>
+Running the execution engine elevated grants it higher privileges. Only enable this when you need to automate applications that run as Administrator.
 </Warning>
 
 ### Need to reinstall or remove

--- a/06-agent-os/index.mdx
+++ b/06-agent-os/index.mdx
@@ -7,7 +7,7 @@ AgentOS is the runtime layer that gives AI agents direct control over a machine'
 
 **Designed for everyone, not just developers.** AgentOS is built so that non-technical users can install it and get it running without writing code or configuring system internals. The UI installer guides you through setup, the SDK auto-detects the service, and sensible defaults mean you don't need to touch configuration files to get started.
 
-**Platform independent.** AgentOS runs on Windows, macOS, and Linux. In [Companion Mode](/06-agent-os/understanding/control-modes#companion-mode), it can also control Android devices, iOS devices (planned), and any machine reachable through hardware interfaces — regardless of what OS the target runs.
+**Platform independent.** AgentOS runs on Windows, macOS, and Linux. In [Companion Mode](/06-agent-os/understanding/control-modes#companion-mode), it can also control Android devices, iOS Simulators (experimental), and any machine reachable through hardware interfaces — regardless of what OS the target runs.
 
 ## How It Works
 
@@ -20,55 +20,18 @@ Both modes expose the same **capabilities** to your agents — the building bloc
 
 ## Why AgentOS?
 
-Building a Computer Use Agent (CUA) proof-of-concept is straightforward — a few scripts with PyAutoGUI or xdotool and you have a demo running in minutes. But getting it to **production** is a different story. The gap between "works on my machine" and "runs reliably at scale" is where most teams get stuck. Especially CI/CD integration becomes a struggle — VMs start at the logon screen, automation requires an interactive user session, and OS security restrictions block input injection from non-interactive processes. Solving this means dealing with session management, login automation, and privilege escalation before your agent can even begin its work.
+Building a Computer Use Agent (CUA) proof-of-concept is straightforward — a few scripts with PyAutoGUI or xdotool and you have a demo running in minutes. But getting it to **production** is a different story. The gap between "works on my machine" and "runs reliably at scale" is where most teams get stuck. CI/CD integration is where it gets especially painful — VMs start at the logon screen, automation requires an interactive user session, and OS security restrictions block input injection from non-interactive processes. Solving this means dealing with session management, login automation, and privilege escalation before your agent can even begin its work.
 
-### vs. Open Source (PyAutoGUI, xdotool, etc.)
+See our detailed comparisons for more:
 
-Open-source desktop automation libraries run **in the user's session only**. That works for simple scripting but breaks down for real-world agent deployments:
-
-- **No service mode** — when the user logs off or the RDP session disconnects, automation stops.
-- **No logon screen control** — you can't automate Windows logon, lock screens, or UAC prompts.
-- **No CTRL+ALT+DEL** — Secure Attention Sequence requires a kernel-level driver. User-space tools cannot send it.
-- **No session resilience** — if an RDP session drops, the desktop locks and screenshots go black.
-- **User-level privileges only** — no access to SYSTEM-level operations.
-- **Broken coordinate mapping** — mouse coordinates, screenshot pixels, and OS display scaling (DPI) use different coordinate systems. Open-source tools don't unify them, so clicks land in the wrong place on scaled or multi-monitor setups.
-- **US ASCII only** — most libraries only support US keyboard layouts. Dead keys, compose sequences, non-Latin characters, and layout-dependent keys either fail silently or produce wrong input.
-- **Hardware-dependent key events** — connecting or disconnecting external keyboards changes how the OS reports key events. Open-source tools don't account for this, leading to missed or misinterpreted key presses.
-- **No display change recovery** — when displays are connected, disconnected, or change resolution, the desktop layout shifts. Open-source tools don't detect or recover from this, causing automation to break silently.
-
-### vs. Building It Yourself
-
-You *can* build OS-level control from scratch. Here's what that involves:
-
-- **Windows service with session management** — running as SYSTEM, attaching to interactive sessions, handling session 0 isolation.
-- **Secure Attention Sequence driver** — a signed kernel driver to send CTRL+ALT+DEL.
-- **RDP session transfer** — detecting disconnects and keeping the desktop alive for screenshot capture.
-- **Logon screen interaction** — injecting input on the secure desktop.
-- **Cross-version compatibility** — handling differences across Windows 10, 11, Server 2019, 2022.
-- **Coordinate system unification** — mouse coordinates, screenshot pixel coordinates, and OS display scaling (DPI) each use different coordinate systems. You need to map between them so that a click lands exactly where the agent sees it on the screenshot, across all resolutions and scaling factors.
-- **Keyboard input handling** — OS-level key events change depending on connected hardware (e.g. plugging in an external keyboard can alter scan codes and event routing). You also need to support all keys across all keyboard layouts — not just US ASCII — including dead keys, compose sequences, and Unicode characters that don't exist on a standard US keyboard.
-- **Display connect/disconnect handling** — monitors get plugged in, unplugged, or change resolution at runtime. You need to detect these events, update your coordinate mapping, and recover the automation session without losing state.
-
-This is months of kernel and systems-level engineering before you write a single line of agent logic.
-
-<Tip>
-Ask yourself: do you really want your engineers debugging why a click lands 10 pixels off on a 150% DPI display, or why a key press gets swallowed when a second keyboard is connected? Every hour spent on platform-specific input quirks is an hour not spent on your agent's actual logic. AgentOS handles the OS layer so your team can focus on solving your business problem with your agent.
-</Tip>
-
-### Comparison
-
-| Capability | AgentOS | Open Source | DIY |
-| --- | --- | --- | --- |
-| OS service mode | Yes | No | Months of work |
-| RDP resilience | Yes | No | Kernel-level effort |
-| Logon screen control | Yes | No | Requires SAS driver |
-| Send CTRL+ALT+DEL | Yes | No | Requires signed kernel driver |
-| CI/CD headless | Yes | No | Custom service wrapper |
-| SYSTEM privileges | Yes | No | Manual service setup |
-| External device control | Yes | No | Custom hardware integration |
-| Industry protocols | Planned | No | Custom integration per protocol |
-| Maintained and versioned | Yes | Varies | On you |
-| Time to first automation | Minutes | Hours | Months |
+<CardGroup cols={2}>
+  <Card title="vs Automation Libraries" icon="code" href="/06-agent-os/understanding/comparison/vs-automation-libs">
+    PyAutoGUI, RobotJS, xdotool, and why they fall short in production.
+  </Card>
+  <Card title="vs Remote Control Software" icon="display" href="/06-agent-os/understanding/comparison/vs-remote-control">
+    RDP, TeamViewer, VNC, RustDesk — built for humans, not agents.
+  </Card>
+</CardGroup>
 
 ## What's Next?
 

--- a/06-agent-os/installation/silent.mdx
+++ b/06-agent-os/installation/silent.mdx
@@ -24,9 +24,9 @@ Run from an **elevated** command prompt (Run as administrator):
 "AskUI-Agent-OS-<version>-Service-Installer-Win-AMD64.exe" /qn
 ```
 
-<Note>Replace `<version>` with the actual version number (e.g. `26.2.1.3`). `<installer_path>` is the full path to where you downloaded the installer.</Note>
+<Note>Replace `<version>` with the actual version number (e.g. `26.2.1.3`).</Note>
 
-With custom options:
+With custom options (replace `<installer_path>` with the full path to where you downloaded the installer):
 
 ```bash
 "<installer_path>" /qn APPDIR="C:\ASKUI" /l*vx installer.log

--- a/06-agent-os/installation/standalone.mdx
+++ b/06-agent-os/installation/standalone.mdx
@@ -28,6 +28,9 @@ pip install askui-agent-os
 ## What's Next?
 
 <CardGroup cols={2}>
+  <Card title="Getting Started" icon="play" href="https://github.com/askui/python-sdk">
+    Build your first agent with the AskUI Python SDK.
+  </Card>
   <Card title="Runtime Modes" icon="toggle-on" href="/06-agent-os/understanding/runtime-modes">
     Understand standalone vs OS service mode.
   </Card>

--- a/06-agent-os/reference/system-requirements.mdx
+++ b/06-agent-os/reference/system-requirements.mdx
@@ -5,7 +5,7 @@ description: Hardware, software, and platform requirements for AgentOS.
 
 ## Operating System Requirements
 
-- **Windows**: Windows 10 version 1511+ (64-bit), Windows 11 (64-bit), Windows Server 2016/2019/2022/2025 (64-bit)
+- **Windows**: Windows 10 version 1511+ (64-bit), Windows 11 (64-bit), Windows Server 2019/2022/2025 (64-bit)
 - **macOS**: macOS 10.15 (Catalina) or newer
 - **Linux**: Ubuntu 18.04 or newer
 
@@ -43,7 +43,6 @@ description: Hardware, software, and platform requirements for AgentOS.
 
 | Version | Channel | Supported |
 |---------|---------|-----------|
-| 2016 | LTSC | x64 |
 | 2019 | LTSC | x64 |
 | 2022 | LTSC | x64 |
 | 2025 | LTSC | x64 |

--- a/06-agent-os/understanding/capabilities.mdx
+++ b/06-agent-os/understanding/capabilities.mdx
@@ -39,7 +39,7 @@ These capabilities require AgentOS to be installed as a [Windows service](/06-ag
 | Capability | Status | Description |
 | --- | --- | --- |
 | ADB (Android) | Available | Control Android devices via USB. |
-| IDB (iOS) | Planned | Control iOS devices via USB. |
+| IDB (iOS) | Experimental | Control iOS Simulators (macOS only). |
 
 ## Hardware (Companion Mode Only)
 
@@ -56,13 +56,12 @@ These capabilities require AgentOS to be installed as a [Windows service](/06-ag
 | --- | --- | --- |
 | Windows 10 22H2+ | Available | — |
 | Windows 11 | Available | — |
-| Windows Server 2022+ | Available | — |
+| Windows Server 2019+ | Available | — |
 | Windows 10 < 22H2 | Available | — |
-| Windows Server 2019 | Available | — |
 | macOS | Available | — |
 | Linux | Available | — |
 | Android | — | Available (ADB) |
-| iOS | — | Planned (IDB) |
+| iOS | — | Experimental (IDB, Simulators only) |
 
 ## Future
 

--- a/06-agent-os/understanding/comparison/vs-automation-libs.mdx
+++ b/06-agent-os/understanding/comparison/vs-automation-libs.mdx
@@ -1,0 +1,68 @@
+---
+title: AgentOS vs Automation Libraries
+description: How AgentOS differs from PyAutoGUI, RobotJS, xdotool, and other open-source automation tools.
+---
+
+Open-source desktop automation libraries like PyAutoGUI, RobotJS, xdotool, and similar tools let you script mouse clicks, key presses, and screenshots. They work well for simple scripting but break down when you move to production-grade agent deployments.
+
+## The Problem
+
+These libraries run **in the user's session only**. That means:
+
+- **No service mode** — when the user logs off or the RDP session disconnects, automation stops.
+- **No logon screen control** — you can't automate Windows logon, lock screens, or UAC prompts.
+- **No CTRL+ALT+DEL** — Secure Attention Sequence requires a kernel-level driver. User-space tools cannot send it.
+- **No session resilience** — if an RDP session drops, the desktop locks and screenshots go black.
+- **User-level privileges only** — no access to SYSTEM-level operations.
+- **No multi-display support** — most libraries only see the primary monitor. Automating across multiple displays requires manual coordinate offsets and per-display screenshot stitching.
+- **Wrong mouse-image coordinate system** — mouse coordinates and screenshot pixel coordinates use different coordinate systems, especially with DPI scaling. A position on the screenshot doesn't map 1:1 to where the mouse actually clicks, causing agents to miss their targets.
+- **US ASCII only** — most libraries only support US keyboard layouts. Dead keys, compose sequences, non-Latin characters, and layout-dependent keys either fail silently or produce wrong input.
+- **Hardware-dependent key events** — connecting or disconnecting external keyboards changes how the OS reports key events. These tools don't account for this, leading to missed or misinterpreted key presses.
+- **No display change recovery** — when displays are connected, disconnected, or change resolution, the desktop layout shifts. These tools don't detect or recover from this, causing automation to break silently.
+
+## Library Comparison
+
+| Library | Language | Platform | Limitations |
+| --- | --- | --- | --- |
+| [PyAutoGUI](https://pyautogui.readthedocs.io/) | Python | Windows, macOS, Linux | No service mode, no DPI handling, US keyboard only, no CI/CD support |
+| [RobotJS](http://robotjs.io/) | Node.js | Windows, macOS, Linux | Unmaintained, no Unicode support, no multi-monitor, no service mode |
+| [xdotool](https://github.com/jordansissel/xdotool) | CLI | Linux (X11 only) | Linux only, no Wayland, no service mode, no DPI handling |
+| [pynput](https://pynput.readthedocs.io/) | Python | Windows, macOS, Linux | Listener-focused, limited input simulation, no service mode |
+| [AutoIt](https://www.autoitscript.com/) | AutoIt | Windows only | Windows only, no service mode, no cross-platform |
+
+## AgentOS vs Automation Libraries
+
+| Capability | AgentOS | Automation Libraries |
+| --- | --- | --- |
+| OS service mode | Yes | No |
+| RDP resilience | Yes | No |
+| Logon screen control | Yes | No |
+| Send CTRL+ALT+DEL | Yes | No |
+| CI/CD headless | Yes | No |
+| SYSTEM privileges | Yes | No |
+| Unified coordinate system | Yes | No |
+| All keyboard layouts & Unicode | Yes | No (US ASCII mostly) |
+| Display connect/disconnect recovery | Yes | No |
+| External device control | Yes | No |
+| Cross-platform (Windows, macOS, Linux) | Yes | Varies |
+| Mobile devices (Android, iOS) | Yes | No |
+| Optimized for token costs & latency | Yes | Not designed for AI agents |
+
+## vs. Building It Yourself
+
+You *can* build OS-level control from scratch. Here's what that involves:
+
+- **Windows service with session management** — running as SYSTEM, attaching to interactive sessions, handling session 0 isolation.
+- **Secure Attention Sequence driver** — a signed kernel driver to send CTRL+ALT+DEL.
+- **RDP session transfer** — detecting disconnects and keeping the desktop alive for screenshot capture.
+- **Logon screen interaction** — injecting input on the secure desktop.
+- **Cross-version compatibility** — handling differences across Windows 10, 11, Server 2019, 2022.
+- **Coordinate system unification** — mouse coordinates, screenshot pixel coordinates, and OS display scaling (DPI) each use different coordinate systems. You need to map between them so that a click lands exactly where the agent sees it on the screenshot, across all resolutions and scaling factors.
+- **Keyboard input handling** — OS-level key events change depending on connected hardware (e.g. plugging in an external keyboard can alter scan codes and event routing). You also need to support all keys across all keyboard layouts — not just US ASCII — including dead keys, compose sequences, and Unicode characters that don't exist on a standard US keyboard.
+- **Display connect/disconnect handling** — monitors get plugged in, unplugged, or change resolution at runtime. You need to detect these events, update your coordinate mapping, and recover the automation session without losing state.
+
+This is months of kernel and systems-level engineering before you write a single line of agent logic.
+
+<Tip>
+Ask yourself: do you really want your engineers debugging why a click lands 10 pixels off on a 150% DPI display, or why a key press gets swallowed when a second keyboard is connected? Every hour spent on platform-specific input quirks is an hour not spent solving your business problem with your agent. AgentOS handles the OS layer so your team can focus on what matters.
+</Tip>

--- a/06-agent-os/understanding/comparison/vs-remote-control.mdx
+++ b/06-agent-os/understanding/comparison/vs-remote-control.mdx
@@ -84,7 +84,7 @@ AgentOS starts as a Windows service on boot, requires no active session, and is 
 | CI/CD ready | Yes | No | No | No | No |
 | No software on target | Yes (Companion Mode) | Requires RDP server | Requires agent | Requires VNC server | Requires agent |
 
-## Agent-Human-Interaction
+## Agent-Human Interaction
 
 Remote control software is built for one model: a human controls a remote machine. AgentOS is building towards a collaborative model where **agents and humans work on the same machine together**.
 

--- a/06-agent-os/understanding/concepts.mdx
+++ b/06-agent-os/understanding/concepts.mdx
@@ -5,7 +5,7 @@ description: The key concepts behind AgentOS — how control modes, runtime mode
 
 AgentOS has three core concepts that determine what it can do and how it connects to a target machine. While the concepts below involve OS-level services, kernel drivers, and hardware interfaces, **you don't need to understand these internals to use AgentOS**. The installer handles the complexity — non-technical users can set up AgentOS through a guided UI without touching configuration files or the command line.
 
-AgentOS is **platform independent** — it supports Windows, macOS, Linux, Android, and iOS (planned), so the same agent code works across operating systems.
+AgentOS is **platform independent** — it supports Windows, macOS, Linux, Android, and iOS Simulators (experimental), so the same agent code works across operating systems.
 
 ```mermaid
 graph TD
@@ -42,7 +42,7 @@ The runtime mode only applies to Host Mode. Companion Mode always runs standalon
 
 ## Capabilities
 
-Capabilities are the building blocks your agents use — screenshots, keyboard input, mouse control, window management, process management, and more.
+Capabilities are the building blocks your agents use — screenshots, keyboard input, mouse control, window management, process management, and more. All capabilities are optimized for **token cost efficiency**, **low latency**, and **cross-device communication**.
 
 What's available depends on the combination of control mode and runtime mode:
 
@@ -56,6 +56,38 @@ What's available depends on the combination of control mode and runtime mode:
 | Mobile devices (ADB/IDB) | — | — | Yes |
 
 [See all Capabilities →](/06-agent-os/understanding/capabilities)
+
+## Administrator Rights (Windows)
+
+AgentOS consists of two components: the **AgentOS Service** and the **Remote Device Controller** (internally called the *Execution Engine* in installer parameters). Each can run *elevated* (with administrator privileges) or *non-elevated* (standard user privileges). Elevation determines what your agent can interact with — Windows prevents non-elevated processes from sending input to elevated applications.
+
+<Note>
+**Session 0 vs Interactive Session**: Windows runs services in **Session 0** — an isolated, non-interactive session with no desktop. Users log in to **Interactive Sessions** (Session 1, 2, ...) where the desktop and GUI applications live. The AgentOS OS Service runs in Session 0 but attaches to the user's interactive session to control the desktop. This is why it can keep automating even when no user is logged in or an RDP session disconnects.
+</Note>
+
+### Standalone
+
+| Component | Default | Elevated |
+| --- | --- | --- |
+| AgentOS | Not elevated (recommended) | Run with admin rights |
+| Remote Device Controller | Not elevated (recommended) | Run with admin rights |
+
+In standalone mode, both components run with the privileges of the current user. This is sufficient for most development scenarios. Only run with admin rights if you need to automate applications that themselves run as Administrator.
+
+### OS Service
+
+| Component | Default | Configurable |
+| --- | --- | --- |
+| AgentOS | Elevated (SYSTEM) | — |
+| Remote Device Controller | Not elevated (recommended) | `SERVICE_EXECUTION_ENGINE_ELEVATED=1` |
+
+The OS Service always runs AgentOS as SYSTEM (elevated). The Remote Device Controller defaults to non-elevated, which is recommended. Enable elevation for the controller only if your agent needs to interact with applications running as Administrator.
+
+<Tip>
+We recommend the **principle of least privilege**: keep both components non-elevated unless your agent specifically needs to automate admin-level applications. Only elevate what is necessary.
+</Tip>
+
+If your agent can't interact with an elevated application, see [Troubleshooting](/06-agent-os/how-to-guides/troubleshooting#agent-cant-interact-with-apps-running-as-administrator).
 
 ## How They Fit Together
 

--- a/06-agent-os/understanding/runtime-modes.mdx
+++ b/06-agent-os/understanding/runtime-modes.mdx
@@ -30,7 +30,8 @@ The OS service requires the [Windows installer](/06-agent-os/installation/servic
 | Feature | Standalone | OS Service |
 | --- | --- | --- |
 | **Primary use** | Local dev / desktop | Enterprise / CI/CD |
-| **CI/CD ready** | No | Yes (unattended/headless) |
+| **CI/CD ready (Windows)** | No (requires OS service) | Yes (unattended/headless) |
+| **CI/CD ready (macOS/Linux)** | Yes | — |
 | **RDP resilience** | No (session locks on disconnect) | Yes (session transfer) |
 | **Logon screen control** | No | Yes |
 | **Send CTRL+ALT+DEL** | No | Yes (Secure Attention Sequence) |

--- a/mint.json
+++ b/mint.json
@@ -520,7 +520,13 @@
             "06-agent-os/understanding/capabilities",
             "06-agent-os/understanding/runtime-modes",
             "06-agent-os/understanding/control-modes",
-            "06-agent-os/understanding/vs-remote-control"
+            {
+              "group": "Comparison",
+              "pages": [
+                "06-agent-os/understanding/comparison/vs-automation-libs",
+                "06-agent-os/understanding/comparison/vs-remote-control"
+              ]
+            }
           ]
         },
         {

--- a/snippets/agent-os-mobile-setup.mdx
+++ b/snippets/agent-os-mobile-setup.mdx
@@ -18,8 +18,8 @@
       </Step>
     </Steps>
   </Accordion>
-  <Accordion title="iOS: Setting up IDB (macOS only)">
-    iOS automation requires macOS with Xcode and the Facebook IDB companion. IDB currently only works with **iOS Simulators**, not physical devices. See Apple's guide on [running your app in Simulator](https://developer.apple.com/documentation/xcode/running-your-app-in-simulator-or-on-a-device) to get started.
+  <Accordion title="iOS: Setting up IDB (macOS only, experimental)">
+    iOS automation requires macOS with Xcode and the Facebook IDB companion. IDB currently only works with **iOS Simulators**, not physical devices. This feature is **experimental**. See Apple's guide on [running your app in Simulator](https://developer.apple.com/documentation/xcode/running-your-app-in-simulator-or-on-a-device) to get started.
 
     <Steps>
       <Step title="Install Xcode with iOS Simulators">


### PR DESCRIPTION
- Add comparison sub-group with dedicated pages for automation libs (PyAutoGUI, RobotJS, xdotool) and remote control software
- Fix CI/CD readiness: standalone works on macOS/Linux, not Windows
- Standardize Windows Server support to 2019+ across all pages
- Change iOS status from Planned to Experimental (Simulators only)
- Clarify Remote Device Controller / Execution Engine terminology
- Add elevated apps troubleshooting and admin rights concept section
- Add getting started link to python-sdk on standalone page
- Polish: fix awkward phrasing, heading format, installer note placement