### PR TITLE
docs: simplify AgentOS concepts diagram and scope admin rights to Hos…

### DIFF
--- a/06-agent-os/understanding/concepts.mdx
+++ b/06-agent-os/understanding/concepts.mdx
@@ -8,13 +8,16 @@ AgentOS has three core concepts that determine what it can do and how it connect
 AgentOS is **platform independent** — it supports Windows, macOS, Linux, Android, and iOS Simulators (experimental), so the same agent code works across operating systems.
 
 ```mermaid
-graph TD
-    A[Agent Code<br/>Python SDK] -->|gRPC| B[AgentOS Service Binary]
-    B --> C{Runtime Mode<br/>How is the binary started?}
-    C -->|Standalone<br/>started by external program<br/>user privileges| D{Control Mode<br/>What does the binary control?}
-    C -->|OS Service<br/>registered as OS service<br/>SYSTEM privileges| D
-    D -->|Host Mode| E[Local host<br/>via OS-level APIs]
-    D -->|Companion Mode| F[Companion device<br/>via protocol]
+graph LR
+    S[Python SDK] -->|gRPC| A[AgentOS] --> B[Runtime Mode] --> C[Control Mode] --> D[Target Device]
+
+    classDef navy fill:#282650,stroke:#282650,color:#ffffff
+    classDef light fill:#f7f6f5,stroke:#282650,color:#282650,stroke-width:2px
+    classDef target fill:#ffffff,stroke:#282650,color:#282650,stroke-width:2px,stroke-dasharray: 4 4
+
+    class S,A navy
+    class B,C light
+    class D target
 ```
 
 ## Control Modes
@@ -57,6 +60,10 @@ What's available depends on the combination of control mode and runtime mode:
 [See all Capabilities →](/06-agent-os/understanding/capabilities)
 
 ## Administrator Rights (Windows)
+
+<Note>
+**Applies to Host Mode only.** In Companion Mode, AgentOS runs on a separate device and reaches the target through hardware bridges (USB, Bluetooth, HDMI capture) or device protocols (ADB, IDB), so Windows privileges on the target are not relevant.
+</Note>
 
 AgentOS consists of two components: the **AgentOS Service** and the **Remote Device Controller** (internally called the *Execution Engine* in installer parameters). Each can run *elevated* (with administrator privileges) or *non-elevated* (standard user privileges). Elevation determines what your agent can interact with — Windows prevents non-elevated processes from sending input to elevated applications.
 


### PR DESCRIPTION
…t Mode

Replace the multi-decision diagram with a linear flow Python SDK -> AgentOS -> Runtime Mode -> Control Mode -> Target Device, styled with askui brand colors (navy for software components, light for configuration axes, dashed outline for the external target). Add a Note to the Administrator Rights section clarifying it applies only to Host Mode, since Companion Mode reaches the target through hardware bridges where Windows privileges are not relevant.